### PR TITLE
Fix thread synchronisation

### DIFF
--- a/autopts/client.py
+++ b/autopts/client.py
@@ -793,7 +793,7 @@ def run_test_case_thread_entry(pts, test_case, exceptions):
         test_case.status = "RUNNING"
         test_case.state = "RUNNING"
         pts.callback_thread.set_current_test_case(test_case.name)
-        synchronize_instances(test_case.state)
+        synchronize_instances(test_case.state, ["FINISHING"])
         error_code = pts.run_test_case(test_case.project_name, test_case.name)
 
         log("After run_test_case error_code=%r status=%r",


### PR DESCRIPTION
When test case needs two dongles and one of them failed on prerun they stack on synchronize_instances.

(cherry picked from commit fd414937c7496588bb6ceb3d3e0d86bb899ec10a)
Signed-off-by: Alperen Sener <alperen.sener@nordicsemi.no>