### PR TITLE
Path resolve fix for windows

### DIFF
--- a/autopts/utils.py
+++ b/autopts/utils.py
@@ -36,7 +36,11 @@ from autopts.config import FILE_PATHS
 PTS_WORKSPACE_FILE_EXT = ".pqw6"
 
 # Global paths for wid report
-BASE_DIR = Path(__file__).parent.parent.resolve()
+BASE_DIR = Path(__file__).parent.parent
+try:
+    BASE_DIR = BASE_DIR.resolve()
+except OSError:
+    BASE_DIR = BASE_DIR.absolute()
 LOG_DIR = BASE_DIR / "logs"
 
 # Regex patterns for log field parsing in wid report
@@ -583,7 +587,11 @@ def extract_wid_testcases_to_csv(log_dir: Path = None):
                 testcases_combined = " ".join(testcases)
                 writer.writerow([wid, testcases_combined])
 
-    print(f"WID usage report saved to: {OUTPUT_CSV_PATH.resolve()}")
+    try:
+        _wid_path = OUTPUT_CSV_PATH.resolve()
+    except OSError:
+        _wid_path = OUTPUT_CSV_PATH.absolute()
+    print(f"WID usage report saved to: {_wid_path}")
 
 
 Sep = re.compile(r'[,\s;|]+')


### PR DESCRIPTION
resolve calls on windows machine give the following error:

OSError: [WinError 1005] The volume does not contain a recognized file system.

I suggest merging this to downstream until proper fix is found and merged into upstream AutoPTS