### PR TITLE
zephyr: add test cases to exceptioned list for creating sync

### DIFF
--- a/autopts/wid/gap.py
+++ b/autopts/wid/gap.py
@@ -1707,7 +1707,9 @@ def hdl_wid_301(params: WIDParams):
     stack = get_stack()
 
     # GAP/PADV/PASE/BV-02-C starts PA Sync in WID 302 which comes first
-    if params.test_case_name not in ['GAP/PADV/PASE/BV-02-C']:
+    if params.test_case_name not in ['GAP/PADV/PASE/BV-02-C',
+                                     'GAP/PADV/PASE/BV-04-C',
+                                     'GAP/PADV/PASE/BV-06-C']:
         btp.gap_padv_create_sync(0, 0, 500, 0)
 
     return stack.gap.wait_periodic_report(10)


### PR DESCRIPTION
GAP/PADV/PASE/BV-04-C
GAP/PADV/PASE/BV-06-C

Sync is already established in previous steps following previous WIDs, adding test cases in the exception list to not start sync again.